### PR TITLE
Remove aria-label from avatar, in the room timeline

### DIFF
--- a/src/components/views/avatars/MemberAvatar.tsx
+++ b/src/components/views/avatars/MemberAvatar.tsx
@@ -27,7 +27,7 @@ import UserIdentifierCustomisations from "../../../customisations/UserIdentifier
 import { useRoomMemberProfile } from "../../../hooks/room/useRoomMemberProfile";
 import { _t } from "../../../languageHandler";
 
-interface IProps extends Omit<React.ComponentProps<typeof BaseAvatar>, "name" | "idName" | "url"> {
+interface IProps extends Omit<React.ComponentProps<typeof BaseAvatar>, "name" | "idName" | "url" | "altText"> {
     member: RoomMember | null;
     fallbackUserId?: string;
     size: string;
@@ -40,6 +40,7 @@ interface IProps extends Omit<React.ComponentProps<typeof BaseAvatar>, "name" | 
     forceHistorical?: boolean; // true to deny `useOnlyCurrentProfiles` usage. Default false.
     hideTitle?: boolean;
     children?: ReactNode;
+    altText?: string;
 }
 
 export default function MemberAvatar({
@@ -50,6 +51,7 @@ export default function MemberAvatar({
     fallbackUserId,
     hideTitle,
     member: propsMember,
+    altText,
     ...props
 }: IProps): JSX.Element {
     const card = useContext(CardContext);
@@ -80,6 +82,10 @@ export default function MemberAvatar({
         }
     }
 
+    if (!altText) {
+        altText = _t("common|user_avatar");
+    }
+
     return (
         <BaseAvatar
             {...props}
@@ -99,7 +105,7 @@ export default function MemberAvatar({
                       }
                     : props.onClick
             }
-            altText={_t("common|user_avatar")}
+            altText={altText}
         />
     );
 }

--- a/test/components/views/avatars/MemberAvatar-test.tsx
+++ b/test/components/views/avatars/MemberAvatar-test.tsx
@@ -71,4 +71,26 @@ describe("MemberAvatar", () => {
 
         expect(avatar!.getAttribute("src")).not.toBe("");
     });
+
+    it("should render altText", async () => {
+        const { container } = render(getComponent({altText: "foo"}));
+
+        let avatar: HTMLElement;
+        await waitFor(() => {
+            avatar = getByTestId(container, "avatar-img");
+        });
+
+        expect(avatar!.getAttribute("aria-label")).toBe("foo");
+    });
+
+    it("should use default value for altText", async () => {
+        const { container } = render(getComponent({}));
+
+        let avatar: HTMLElement;
+        await waitFor(() => {
+            avatar = getByTestId(container, "avatar-img");
+        });
+
+        expect(avatar!.getAttribute("aria-label")).toBe("Profile picture");
+    });
 });


### PR DESCRIPTION
WIP

## Before

<img width="624" alt="before" src="https://github.com/Automattic/matrix-react-sdk/assets/550401/e74cc80d-370f-4380-9bfa-5ee9cd4f4737">


```html
<div class="mx_EventTile_avatar">
    <button role="button" aria-label="Profile picture" title="@foo:example.org" aria-live="off" data-testid="avatar-img" data-type="round" data-color="1" class="_avatar_ylj7w_17 mx_BaseAvatar" style="--cpd-avatar-size: 30px;">
        <img loading="lazy" alt="" src="https://example.org/_matrix/media/v3/thumbnail/matrix.org/redacted?width=60&amp;height=60&amp;method=crop" crossorigin="anonymous" referrerpolicy="no-referrer" class="_image_ylj7w_45" data-type="round" width="30px" height="30px">
    </button>
</div>
```

## After

TODO
